### PR TITLE
Add executable to root for easier access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ build/
 dist/
 *.spec
 
-# All executables (GPMatcher, ExifTool, etc.)
-*.exe
+
+exiftool.exe
 
 # ExifTool extra files
 exiftool_files/


### PR DESCRIPTION
I think it's better to place this .exe file at the root of the repo so users can find the executable easily (instead of having to look for it in the releases)
What do you think about it ?